### PR TITLE
Added mysql2 promise support and tests

### DIFF
--- a/lib/instrumentation.js
+++ b/lib/instrumentation.js
@@ -43,8 +43,12 @@ exports.callbackInitialize = function callbackInitialize(shim, mysql) {
   }
 }
 
-exports.promiseInitialize = function promiseInitialize(shim, mysql) {
+exports.promiseInitialize = function promiseInitialize(shim) {
+  const callbackAPI = shim.require('./index')
 
+  if (callbackAPI && !shim.isWrapped(callbackAPI.createConnection)) {
+    exports.callbackInitialize(shim, callbackAPI)
+  }
 }
 
 function wrapGetConnection(shim, connectable) {

--- a/tests/versioned/common/basic-pool.js
+++ b/tests/versioned/common/basic-pool.js
@@ -7,17 +7,15 @@ const urltils = require('newrelic/lib/util/urltils') // TODO: Expose via test ut
 const utils = require('@newrelic/test-utilities')
 
 const params = setup.params
-const DBUSER = 'root'
-const DBNAME = 'agent_integration'
 
 var config = getConfig({})
 function getConfig(extras) {
   var conf = {
     connectionLimit: 10,
-    host: params.mysql_host,
-    port: params.mysql_port,
-    user: DBUSER,
-    database: DBNAME
+    host: params.host,
+    port: params.port,
+    user: params.user,
+    database: params.database
   }
 
   for (var key in extras) { // eslint-disable-line guard-for-in
@@ -43,8 +41,8 @@ module.exports = (t, requireMySQL) => {
     var badConfig = {
       connectionLimit: 10,
       host: 'nohost',
-      user: DBUSER,
-      database: DBNAME
+      user: params.user,
+      database: params.database
     }
 
     t.tearDown(() => {
@@ -129,7 +127,7 @@ module.exports = (t, requireMySQL) => {
           )
           t.equal(
             seg.parameters.database_name,
-            DBNAME,
+            params.database,
             'set database name'
           )
           t.equal(
@@ -160,7 +158,7 @@ module.exports = (t, requireMySQL) => {
           )
           t.equal(
             seg.parameters.database_name,
-            DBNAME,
+            params.database,
             'should set database name'
           )
           helper.agent.config.datastore_tracer.instance_reporting.enabled = true
@@ -219,7 +217,7 @@ module.exports = (t, requireMySQL) => {
           )
           t.equal(
             seg.parameters.database_name,
-            DBNAME,
+            params.database,
             'set database name'
           )
           t.equal(seg.parameters.port_path_or_id, String(defaultConfig.port), 'set port')
@@ -248,7 +246,7 @@ module.exports = (t, requireMySQL) => {
           )
           t.equal(
             seg.parameters.database_name,
-            DBNAME,
+            params.database,
             'should set database name'
           )
           t.equal(
@@ -381,7 +379,7 @@ module.exports = (t, requireMySQL) => {
               )
               t.equal(
                 seg.parameters.database_name,
-                DBNAME,
+                params.database,
                 'set database name'
               )
               txn.end(socketPool.end.bind(socketPool, t.end))

--- a/tests/versioned/common/basic.js
+++ b/tests/versioned/common/basic.js
@@ -177,9 +177,9 @@ module.exports = (t, requireMySQL) => {
                 t.ok(seg, 'there is a segment')
                 t.equal(
                   seg.parameters.host,
-                  urltils.isLocalhost(params.mysql_host)
+                  urltils.isLocalhost(params.host)
                     ? helper.agent.config.getHostnameSafe()
-                    : params.mysql_host,
+                    : params.host,
                   'set host'
                 )
                 t.equal(

--- a/tests/versioned/common/basic.js
+++ b/tests/versioned/common/basic.js
@@ -157,7 +157,7 @@ module.exports = (t, requireMySQL) => {
       })
     })
 
-    t.test('ensure database name changes with a use statement', (t) => {
+    t.test('database name should change with use statement', (t) => {
       helper.runInTransaction((txn) => {
         withRetry.getClient((err, client) => {
           if (!t.error(err)) {
@@ -349,46 +349,6 @@ module.exports = (t, requireMySQL) => {
             txn.end(() => {
               checkQueries(t, helper)
               t.end()
-            })
-          })
-        })
-      })
-    })
-
-    t.test('ensure database name changes with a use statement', (t) => {
-      helper.runInTransaction((txn) => {
-        withRetry.getClient((err, client) => {
-          client.query('create database if not exists test_db;', (err) => {
-            t.error(err)
-            client.query('use test_db;', (err) => {
-              t.error(err)
-              client.query('SELECT 1 + 1 AS solution', (err) => {
-                var seg = helper.agent.tracer.getSegment().parent
-                t.error(err)
-                if (t.ok(seg, 'should have a segment')) {
-                  t.equal(
-                    seg.parameters.host,
-                    urltils.isLocalhost(params.mysql_host)
-                      ? helper.agent.config.getHostnameSafe()
-                      : params.mysql_host,
-                    'should set host parameter'
-                  )
-                  t.equal(
-                    seg.parameters.database_name,
-                    'test_db',
-                    'should use new database name'
-                  )
-                  t.equal(
-                    seg.parameters.port_path_or_id,
-                    '3306',
-                    'should set port parameter'
-                  )
-                }
-                client.query('drop test_db;', () => {
-                  withRetry.release(client)
-                  txn.end(t.end)
-                })
-              })
             })
           })
         })

--- a/tests/versioned/common/pooling.js
+++ b/tests/versioned/common/pooling.js
@@ -5,10 +5,6 @@ const setup = require('./setup')
 const utils = require('@newrelic/test-utilities')
 
 
-const DBNAME = 'agent_integration'
-const DBTABLE = 'test'
-
-
 module.exports = (t, requireMySQL) => {
   t.test('MySQL instrumentation with a connection pool', {timeout: 30000}, (t) => {
     let helper = utils.TestAgent.makeInstrumented()
@@ -64,10 +60,7 @@ module.exports = (t, requireMySQL) => {
             return
           }
 
-          var query =
-            'SELECT *' +
-            '  FROM ' + DBNAME + '.' + DBTABLE +
-            ' WHERE id = ?'
+          var query = `SELECT * FROM ${setup.params.database}.test WHERE id = ?`
           client.query(query, [params.id], (err, results) => {
             withRetry.release(client) // always release back to the pool
 
@@ -104,22 +97,26 @@ module.exports = (t, requireMySQL) => {
               return
             }
 
-            t.equals(row.id, 1, 'node-mysql should still work (found id)')
-            t.equals(row.test_value, 'hamburgefontstiv',
-                     'mysql driver should still work (found value)')
+            t.equals(row.id, 1, 'mysql should still work (found id)')
+            t.equals(
+              row.test_value,
+              'hamburgefontstiv',
+              'mysql driver should still work (found value)'
+            )
 
             txn.end()
 
             var trace = txn.trace
             t.ok(trace, 'trace should exist')
             t.ok(trace.root, 'root element should exist.')
-            t.equals(trace.root.children.length, 1, 'There should be only one child.')
 
-            var selectSegment = trace.root.children[0]
+            t.ok(trace.root.children.length < 3, 'should have one or two children')
+
+            var selectSegment = trace.root.children[trace.root.children.length - 1]
             t.ok(selectSegment, 'trace segment for first SELECT should exist')
             t.equals(
               selectSegment.name,
-              'Datastore/statement/MySQL/agent_integration.test/select',
+              `Datastore/statement/MySQL/${setup.params.database}.test/select`,
               'should register as SELECT'
             )
 

--- a/tests/versioned/common/transactions.js
+++ b/tests/versioned/common/transactions.js
@@ -15,11 +15,6 @@ module.exports = (t, requireMySQL) => {
 
     // set up the instrumentation before loading MySQL
     const helper = utils.TestAgent.makeInstrumented()
-    helper.registerInstrumentation({
-      moduleName: 'mysql',
-      type: 'datastore',
-      onRequire: require('../../../lib/instrumentation').callbackInitialize
-    })
     const mysql = requireMySQL(helper)
 
     t.tearDown(() => helper.unload())

--- a/tests/versioned/common/transactions.js
+++ b/tests/versioned/common/transactions.js
@@ -5,8 +5,6 @@ const utils = require('@newrelic/test-utilities')
 
 
 const params = setup.params
-const DBUSER = 'test_user'
-const DBNAME = 'agent_integration'
 
 
 module.exports = (t, requireMySQL) => {
@@ -22,12 +20,7 @@ module.exports = (t, requireMySQL) => {
     setup(mysql, function(error) {
       t.error(error)
 
-      const client = mysql.createConnection({
-        user: DBUSER,
-        database: DBNAME,
-        host: params.mysql_host,
-        port: params.mysql_port
-      })
+      const client = mysql.createConnection(params)
 
       t.tearDown(() => client.end())
 

--- a/tests/versioned/mysql/newrelic.js
+++ b/tests/versioned/mysql/newrelic.js
@@ -1,9 +1,11 @@
+'use strict'
+
 exports.config = {
-  app_name           : ['My Application'],
-  license_key        : 'license key here',
-  logging            : {
-    level : 'debug',
-    filepath : '../../../newrelic_agent.log'
+  app_name: ['My Application'],
+  license_key: 'license key here',
+  logging: {
+    level: 'debug',
+    filepath: '../../../newrelic_agent.log'
   },
   utilization: {
     detect_aws: false,
@@ -13,11 +15,11 @@ exports.config = {
     detect_docker: false
   },
   slow_sql: {
-    enabled: true,
+    enabled: true
   },
-  transaction_tracer : {
+  transaction_tracer: {
     record_sql: 'raw',
     explain_threshold: 0,
-    enabled : true
+    enabled: true
   }
 }

--- a/tests/versioned/mysql2/newrelic.js
+++ b/tests/versioned/mysql2/newrelic.js
@@ -1,9 +1,11 @@
+'use strict'
+
 exports.config = {
-  app_name           : ['My Application'],
-  license_key        : 'license key here',
-  logging            : {
-    level : 'debug',
-    filepath : '../../../newrelic_agent.log'
+  app_name: ['My Application'],
+  license_key: 'license key here',
+  logging: {
+    level: 'debug',
+    filepath: '../../../newrelic_agent.log'
   },
   utilization: {
     detect_aws: false,
@@ -13,11 +15,11 @@ exports.config = {
     detect_docker: false
   },
   slow_sql: {
-    enabled: true,
+    enabled: true
   },
-  transaction_tracer : {
+  transaction_tracer: {
     record_sql: 'raw',
     explain_threshold: 0,
-    enabled : true
+    enabled: true
   }
 }

--- a/tests/versioned/mysql2/package.json
+++ b/tests/versioned/mysql2/package.json
@@ -14,7 +14,8 @@
         "basic-pool.tap.js",
         "basic.tap.js",
         "pooling.tap.js",
-        "transactions.tap.js"
+        "transactions.tap.js",
+        "promises.tap.js"
       ]
     },
     {
@@ -28,7 +29,8 @@
         "basic-pool.tap.js",
         "basic.tap.js",
         "pooling.tap.js",
-        "transactions.tap.js"
+        "transactions.tap.js",
+        "promises.tap.js"
       ]
     }
   ],

--- a/tests/versioned/mysql2/promises.tap.js
+++ b/tests/versioned/mysql2/promises.tap.js
@@ -1,0 +1,134 @@
+'use strict'
+
+const setup = require('../common/setup')
+const tap = require('tap')
+const urltils = require('newrelic/lib/util/urltils') // TODO: Expose via test utilities
+const utils = require('@newrelic/test-utilities')
+
+const params = setup.params
+const DBUSER = 'test_user'
+const DBNAME = 'agent_integration'
+
+
+utils(tap)
+
+tap.test('mysql2 promises', {timeout: 30000}, (t) => {
+  t.autoend()
+
+  let helper = null
+  let mysql = null
+  let client = null
+
+  t.beforeEach((done) => {
+    helper = utils.TestAgent.makeInstrumented()
+
+    // Stub the normal mysql2 instrumentation to avoid it hiding issues with the
+    // promise instrumentation.
+    helper.registerInstrumentation({
+      moduleName: 'mysql2',
+      type: 'datastore',
+      onRequire: () => {}
+    })
+
+    helper.registerInstrumentation({
+      moduleName: 'mysql2/promise',
+      type: 'datastore',
+      onRequire: require('../../../lib/instrumentation').promiseInitialize
+    })
+    mysql = require('mysql2/promise')
+
+    // Perform the setup using the callback API.
+    setup(require('mysql2'), (err) => {
+      if (err) {
+        done(err)
+      } else {
+        mysql.createConnection({
+          user: DBUSER,
+          databsae: DBNAME,
+          host: params.mysql_host,
+          port: params.mysql_port
+        }).then((c) => {client = c; done()}, done)
+      }
+    })
+  })
+
+  t.afterEach((done) => {
+    helper.unload()
+    if (client) {
+      client.end().then(done, done)
+      client = null
+    } else {
+      done()
+    }
+  })
+
+  t.test('basic transaction', (t) => {
+    return helper.runInTransaction((tx) => {
+      return client.query('SELECT 1').then(() => {
+        t.transaction(tx)
+        return endAsync(tx)
+      })
+    }).then(() => checkQueries(t, helper))
+  })
+
+  t.test('query with values', (t) => {
+    return helper.runInTransaction((tx) => {
+      return client.query('SELECT 1', []).then(() => {
+        t.transaction(tx)
+        return endAsync(tx)
+      })
+    }).then(() => checkQueries(t, helper))
+  })
+
+  t.test('database name should change with use statement', (t) => {
+    return helper.runInTransaction((tx) => {
+      return client.query('create database if not exists test_db').then(() => {
+        t.transaction(tx)
+        return client.query('use test_db')
+      }).then(() => {
+        t.transaction(tx)
+        return client.query('SELECT 1 + 1 AS solution')
+      }).then(() => {
+        t.transaction(tx)
+
+        const segment = tx.trace.root.children[2]
+        const parameters = segment.parameters
+        t.equal(parameters.host, getHostName(helper), 'should set host name')
+        t.equal(parameters.database_name, 'test_db', 'should follow use statement')
+        t.equal(parameters.port_path_or_id, '3306', 'should set port')
+
+        return endAsync(tx)
+      })
+    }).then(() => checkQueries(t, helper))
+  })
+
+  t.test('query with options object rather than sql', (t) => {
+    return helper.runInTransaction((tx) => {
+      return client.query({sql: 'SELECT 1'}).then(() => endAsync(tx))
+    }).then(() => checkQueries(t, helper))
+  })
+
+  t.test('query with options object and values', (t) => {
+    return helper.runInTransaction((tx) => {
+      return client.query({sql: 'SELECT 1'}, []).then(() => endAsync(tx))
+    }).then(() => checkQueries(t, helper))
+  })
+})
+
+function checkQueries(t, helper) {
+  const querySamples = helper.agent.queries.samples
+  t.ok(querySamples.size > 0, 'there should be a query sample')
+  for (let sample of querySamples.values()) {
+    t.ok(sample.total > 0, 'the samples should have positive duration')
+  }
+}
+
+function endAsync(tx) {
+  return new Promise((resolve) => tx.end(() => resolve()))
+}
+
+function getHostName(helper) {
+  return urltils.isLocalhost(params.mysql_host)
+    ? helper.agent.config.getHostnameSafe()
+    : params.mysql_host
+}

--- a/tests/versioned/mysql2/promises.tap.js
+++ b/tests/versioned/mysql2/promises.tap.js
@@ -6,8 +6,6 @@ const urltils = require('newrelic/lib/util/urltils') // TODO: Expose via test ut
 const utils = require('@newrelic/test-utilities')
 
 const params = setup.params
-const DBUSER = 'test_user'
-const DBNAME = 'agent_integration'
 
 
 utils(tap)
@@ -42,12 +40,7 @@ tap.test('mysql2 promises', {timeout: 30000}, (t) => {
       if (err) {
         done(err)
       } else {
-        mysql.createConnection({
-          user: DBUSER,
-          databsae: DBNAME,
-          host: params.mysql_host,
-          port: params.mysql_port
-        }).then((c) => {client = c; done()}, done)
+        mysql.createConnection(params).then((c) => {client = c; done()}, done)
       }
     })
   })
@@ -128,7 +121,7 @@ function endAsync(tx) {
 }
 
 function getHostName(helper) {
-  return urltils.isLocalhost(params.mysql_host)
+  return urltils.isLocalhost(params.host)
     ? helper.agent.config.getHostnameSafe()
-    : params.mysql_host
+    : params.host
 }


### PR DESCRIPTION
Fills in instrumentation for mysql2's promise API and adds tests for that interface. The tests are a copy of the callback-based "basic" tests, modified for promises.