### PR TITLE
Release v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 
+### 1.0.1 (2018-10-30):
+
+* Updated test utilities library and stopped deep linking into the agent.
+
 ### 1.0.0 (2018-10-26):
 
 * Initial release of `mysql` and `mysql2` instrumentation as a separate module.

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/newrelic/node-newrelic-mysql#readme",
   "devDependencies": {
-    "@newrelic/test-utilities": "^1.2.1",
+    "@newrelic/test-utilities": "^2.0.0",
     "async": "^2.6.1",
     "coveralls": "^3.0.2",
     "eslint": "^5.7.0",

--- a/tests/versioned/common/basic-pool.js
+++ b/tests/versioned/common/basic-pool.js
@@ -3,7 +3,6 @@
 const exec = require('child_process').exec
 const fs = require('fs')
 const setup = require('./setup')
-const urltils = require('newrelic/lib/util/urltils') // TODO: Expose via test utilities
 const utils = require('@newrelic/test-utilities')
 
 const params = setup.params
@@ -120,9 +119,7 @@ module.exports = (t, requireMySQL) => {
           t.ok(seg, 'should have a segment (' + (seg && seg.name) + ')')
           t.equal(
             seg.parameters.host,
-            urltils.isLocalhost(config.host)
-              ? helper.agent.config.getHostnameSafe()
-              : config.host,
+            utils.getDelocalizedHostname(config.host),
             'set host'
           )
           t.equal(
@@ -176,9 +173,7 @@ module.exports = (t, requireMySQL) => {
           t.ok(seg, 'there is a segment')
           t.equal(
             seg.parameters.host,
-            urltils.isLocalhost(config.host)
-              ? helper.agent.config.getHostnameSafe()
-              : config.host,
+            utils.getDelocalizedHostname(config.host),
             'set host'
           )
           t.equal(
@@ -239,9 +234,7 @@ module.exports = (t, requireMySQL) => {
           t.ok(seg, 'should have a segment')
           t.equal(
             seg.parameters.host,
-            urltils.isLocalhost(config.host)
-              ? helper.agent.config.getHostnameSafe()
-              : config.host,
+            utils.getDelocalizedHostname(config.host),
             'should set host'
           )
           t.equal(

--- a/tests/versioned/common/basic.js
+++ b/tests/versioned/common/basic.js
@@ -4,7 +4,6 @@ process.env.NEW_RELIC_HOME = __dirname
 
 const logger = require('newrelic/lib/logger')
 const setup = require('./setup')
-const urltils = require('newrelic/lib/util/urltils') // TODO: Expose via test utilities
 const utils = require('@newrelic/test-utilities')
 
 
@@ -177,9 +176,7 @@ module.exports = (t, requireMySQL) => {
                 t.ok(seg, 'there is a segment')
                 t.equal(
                   seg.parameters.host,
-                  urltils.isLocalhost(params.host)
-                    ? helper.agent.config.getHostnameSafe()
-                    : params.host,
+                  utils.getDelocalizedHostname(params.host),
                   'set host'
                 )
                 t.equal(

--- a/tests/versioned/mysql2/promises.tap.js
+++ b/tests/versioned/mysql2/promises.tap.js
@@ -2,7 +2,6 @@
 
 const setup = require('../common/setup')
 const tap = require('tap')
-const urltils = require('newrelic/lib/util/urltils') // TODO: Expose via test utilities
 const utils = require('@newrelic/test-utilities')
 
 const params = setup.params
@@ -86,7 +85,11 @@ tap.test('mysql2 promises', {timeout: 30000}, (t) => {
 
         const segment = tx.trace.root.children[2]
         const parameters = segment.parameters
-        t.equal(parameters.host, getHostName(helper), 'should set host name')
+        t.equal(
+          parameters.host,
+          utils.getDelocalizedHostname(params.host),
+          'should set host name'
+        )
         t.equal(parameters.database_name, 'test_db', 'should follow use statement')
         t.equal(parameters.port_path_or_id, '3306', 'should set port')
 
@@ -118,10 +121,4 @@ function checkQueries(t, helper) {
 
 function endAsync(tx) {
   return new Promise((resolve) => tx.end(() => resolve()))
-}
-
-function getHostName(helper) {
-  return urltils.isLocalhost(params.host)
-    ? helper.agent.config.getHostnameSafe()
-    : params.host
 }


### PR DESCRIPTION
### 1.0.1 (2018-10-30):

* Updated test utilities library and stopped deep linking into the agent.
