### PR TITLE
Release v1.0.2

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,4 @@
 package-lock.json
+.eslint*
+*.log
 tests/versioned/*/node_modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 
+### 1.0.2 (2018-11-14):
+
+* Replaced deep-link into agent to retrieve database name with call to
+  `shim.getDatabaseNameFromUseQuery()`.
+
+* Removed more items from the published package.
+
 ### 1.0.1 (2018-10-30):
 
 * Updated test utilities library and stopped deep linking into the agent.


### PR DESCRIPTION
### 1.0.2 (2018-11-14):

* Replaced deep-link into agent to retrieve database name with call to
  `shim.getDatabaseNameFromUseQuery()`.

* Removed more items from the published package.
