### PR TITLE
Downgrade tap to v11 due to dep incompatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ node_js:
   - "8"
   - "9"
   - "10"
+  - "11"
 env:
   - SUITE=lint
   - SUITE=unit

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "mysql": "^2.16.0",
     "mysql2": "^1.6.1",
     "newrelic": "^4.10.0",
-    "tap": "^12.0.1"
+    "tap": "^11.1.5"
   },
   "peerDependencies": {
     "newrelic": "^4.10.0"


### PR DESCRIPTION
Tap recently upgraded their dep of `nyc` to v13. That version of `nyc` does not support back to Node 4.