### PR TITLE
NODE-2063 Make v5 fix compatible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ typings/
 # dotenv environment variables file
 .env
 
+# VS Code settings
+.vscode
+*.code-workspace

--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,7 @@ package-lock.json
 .eslint*
 *.log
 tests/versioned/*/node_modules
+
+# VS Code settings
+.vscode
+*.code-workspace

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ node_js:
   - "8"
   - "9"
   - "10"
-  - "11"
 env:
   - SUITE=lint
   - SUITE=unit

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: node_js
 node_js:
-  - "4"
-  - "5"
   - "6"
   - "7"
   - "8"
@@ -14,10 +12,6 @@ env:
   - SUITE=versioned
 matrix:
   exclude:
-    - node_js: "4"
-      env: SUITE=lint
-    - node_js: "5"
-      env: SUITE=lint
     - node_js: "6"
       env: SUITE=lint
     - node_js: "7"

--- a/lib/instrumentation.js
+++ b/lib/instrumentation.js
@@ -139,8 +139,8 @@ function extractQueryArgs(shim, args) {
   }
 
   // Then determine the query values and callback parameters.
-  if (shim.isArray(args[1])) {
-    // query({opts|sql}, values, callback)
+  if (shim.isArray(args[1]) || (!args[1] && shim.isFunction(args[2]))) {
+    // query({opts|sql}, values, callback) - values can be undefined
     callback = 2
   } else {
     // query({opts|sql}, callback)

--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
     "url": "https://github.com/newrelic/node-newrelic-mysql/issues"
   },
   "homepage": "https://github.com/newrelic/node-newrelic-mysql#readme",
+  "engines": {
+    "node": ">=6.0.0 <11.0.0"
+  },
   "devDependencies": {
     "@newrelic/test-utilities": "^3.0.0",
     "async": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -33,10 +33,10 @@
     "generic-pool": "^2.5.4",
     "mysql": "^2.16.0",
     "mysql2": "^1.6.1",
-    "newrelic": "^5.9.0",
+    "newrelic": "^5.9.1",
     "tap": "^11.1.5"
   },
   "peerDependencies": {
-    "newrelic": ">=5.9.0"
+    "newrelic": ">=5.9.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,17 +26,17 @@
   },
   "homepage": "https://github.com/newrelic/node-newrelic-mysql#readme",
   "devDependencies": {
-    "@newrelic/test-utilities": "^2.0.0",
+    "@newrelic/test-utilities": "^3.0.0",
     "async": "^2.6.1",
     "coveralls": "^3.0.2",
     "eslint": "^5.7.0",
     "generic-pool": "^2.5.4",
     "mysql": "^2.16.0",
     "mysql2": "^1.6.1",
-    "newrelic": "^4.10.0",
+    "newrelic": "^5.9.0",
     "tap": "^11.1.5"
   },
   "peerDependencies": {
-    "newrelic": "^4.10.0"
+    "newrelic": ">=5.9.0"
   }
 }

--- a/tests/versioned/common/basic-pool.js
+++ b/tests/versioned/common/basic-pool.js
@@ -117,22 +117,26 @@ module.exports = (t, requireMySQL) => {
           }
           t.error(err, 'should not error')
           t.ok(seg, 'should have a segment (' + (seg && seg.name) + ')')
+
+          const attributes = seg.getAttributes()
+
           t.equal(
-            seg.parameters.host,
+            attributes.host,
             utils.getDelocalizedHostname(config.host),
             'set host'
           )
           t.equal(
-            seg.parameters.database_name,
+            attributes.database_name,
             params.database,
             'set database name'
           )
           t.equal(
-            seg.parameters.port_path_or_id,
+            attributes.port_path_or_id,
             String(config.port),
             'set port'
           )
-          txn.end(t.end)
+          txn.end()
+          t.end()
         })
       })
     })
@@ -145,21 +149,24 @@ module.exports = (t, requireMySQL) => {
           t.error(err, 'should not error making query')
           t.ok(seg, 'should have a segment')
 
+          const attributes = seg.getAttributes()
+
           t.notOk(
-            seg.parameters.host,
-            'should have no host parameter'
+            attributes.host,
+            'should have no host attribute'
           )
           t.notOk(
-            seg.parameters.port_path_or_id,
-            'should have no port parameter'
+            attributes.port_path_or_id,
+            'should have no port attribute'
           )
           t.equal(
-            seg.parameters.database_name,
+            attributes.database_name,
             params.database,
             'should set database name'
           )
           helper.agent.config.datastore_tracer.instance_reporting.enabled = true
-          txn.end(t.end)
+          txn.end()
+          t.end()
         })
       })
     })
@@ -171,22 +178,26 @@ module.exports = (t, requireMySQL) => {
           var seg = getDatastoreSegment(helper.agent.tracer.getSegment())
           t.notOk(err, 'no errors')
           t.ok(seg, 'there is a segment')
+
+          const attributes = seg.getAttributes()
+
           t.equal(
-            seg.parameters.host,
+            attributes.host,
             utils.getDelocalizedHostname(config.host),
             'set host'
           )
           t.equal(
-            seg.parameters.port_path_or_id,
+            attributes.port_path_or_id,
             String(config.port),
             'set port'
           )
           t.notOk(
-            seg.parameters.database_name,
-            'should have no database name parameter'
+            attributes.database_name,
+            'should have no database name attribute'
           )
           helper.agent.config.datastore_tracer.database_name_reporting.enabled = true
-          txn.end(t.end)
+          txn.end()
+          t.end()
         })
       })
     })
@@ -205,18 +216,25 @@ module.exports = (t, requireMySQL) => {
           // with the query.
           var seg = getDatastoreSegment(helper.agent.tracer.getSegment())
           t.ok(seg, 'there is a segment')
+
+          const attributes = seg.getAttributes()
+
           t.equal(
-            seg.parameters.host,
+            attributes.host,
             helper.agent.config.getHostnameSafe(),
             'set host'
           )
           t.equal(
-            seg.parameters.database_name,
+            attributes.database_name,
             params.database,
             'set database name'
           )
-          t.equal(seg.parameters.port_path_or_id, String(defaultConfig.port), 'set port')
-          txn.end(defaultPool.end.bind(defaultPool, t.end))
+          t.equal(attributes.port_path_or_id, String(defaultConfig.port), 'set port')
+          txn.end()
+
+          defaultPool.end((err) => {
+            t.end(err)
+          })
         })
       })
     })
@@ -232,22 +250,29 @@ module.exports = (t, requireMySQL) => {
 
           t.error(err, 'should not error making query')
           t.ok(seg, 'should have a segment')
+
+          const attributes = seg.getAttributes()
+
           t.equal(
-            seg.parameters.host,
+            attributes.host,
             utils.getDelocalizedHostname(config.host),
             'should set host'
           )
           t.equal(
-            seg.parameters.database_name,
+            attributes.database_name,
             params.database,
             'should set database name'
           )
           t.equal(
-            seg.parameters.port_path_or_id,
+            attributes.port_path_or_id,
             '3306',
             'should set port'
           )
-          txn.end(defaultPool.end.bind(defaultPool, t.end))
+          txn.end()
+
+          defaultPool.end((err) => {
+            t.end(err)
+          })
         })
       })
     })
@@ -257,7 +282,8 @@ module.exports = (t, requireMySQL) => {
         pool.query('BLARG', (err) => {
           t.ok(err, 'should have errored')
           t.transaction(txn)
-          txn.end(t.end)
+          txn.end()
+          t.end()
         })
       })
     })
@@ -266,7 +292,8 @@ module.exports = (t, requireMySQL) => {
       helper.runInTransaction((txn) => {
         pool.query('SET SESSION auto_increment_increment=1')
         setTimeout(() => {
-          txn.end(t.end)
+          txn.end()
+          t.end()
         }, 100)
       })
     })
@@ -279,7 +306,8 @@ module.exports = (t, requireMySQL) => {
           t.error(err, 'should not error')
           t.transaction(txn)
           checkSegment(t, segment, 'MySQL Pool#query')
-          txn.end(t.end)
+          txn.end()
+          t.end()
         })
       })
     })
@@ -293,7 +321,8 @@ module.exports = (t, requireMySQL) => {
             checkSegment(t, segment, 'MySQL Pool#query')
           }
 
-          txn.end(t.end)
+          txn.end()
+          t.end()
         })
       })
     })
@@ -311,7 +340,8 @@ module.exports = (t, requireMySQL) => {
             t.error(err, 'no error ocurred')
             t.transaction(txn)
             checkSegment(t, segment)
-            txn.end(t.end)
+            txn.end()
+            t.end()
           })
         })
       })
@@ -331,7 +361,8 @@ module.exports = (t, requireMySQL) => {
               checkSegment(t, segment)
             }
 
-            txn.end(t.end)
+            txn.end()
+            t.end()
           })
         })
       })
@@ -360,22 +391,26 @@ module.exports = (t, requireMySQL) => {
               // In the case where you don't have a server running on localhost
               // the data will still be correctly associated with the query.
               t.ok(seg, 'there is a segment')
+
+              const attributes = seg.getAttributes()
+
               t.equal(
-                seg.parameters.host,
+                attributes.host,
                 helper.agent.config.getHostnameSafe(),
                 'set host'
               )
               t.equal(
-                seg.parameters.port_path_or_id,
+                attributes.port_path_or_id,
                 socketPath,
                 'set path'
               )
               t.equal(
-                seg.parameters.database_name,
+                attributes.database_name,
                 params.database,
                 'set database name'
               )
-              txn.end(socketPool.end.bind(socketPool, t.end))
+              txn.end()
+              socketPool.end.bind(socketPool, t.end)
             })
           })
         }

--- a/tests/versioned/common/basic-pool.js
+++ b/tests/versioned/common/basic-pool.js
@@ -409,8 +409,10 @@ module.exports = (t, requireMySQL) => {
                 params.database,
                 'set database name'
               )
+
               txn.end()
-              socketPool.end.bind(socketPool, t.end)
+              socketPool.end()
+              t.end()
             })
           })
         }

--- a/tests/versioned/common/basic.js
+++ b/tests/versioned/common/basic.js
@@ -81,10 +81,9 @@ module.exports = (t, requireMySQL) => {
             t.transaction(txn)
             withRetry.release(client)
 
-            txn.end(() => {
-              checkQueries(t, helper)
-              t.end()
-            })
+            txn.end()
+            checkQueries(t, helper)
+            t.end()
           })
         })
       })
@@ -107,10 +106,9 @@ module.exports = (t, requireMySQL) => {
 
             t.transaction(txn)
             withRetry.release(client)
-            txn.end(() => {
-              checkQueries(t, helper)
-              t.end()
-            })
+            txn.end()
+            checkQueries(t, helper)
+            t.end()
           })
         })
       })
@@ -143,10 +141,9 @@ module.exports = (t, requireMySQL) => {
             t.transaction(txn)
             withRetry.release(client)
             t.ok(results, 'results should be received')
-            txn.end(() => {
-              checkQueries(t, helper)
-              t.end()
-            })
+            txn.end()
+            checkQueries(t, helper)
+            t.end()
           })
         })
       })
@@ -168,28 +165,29 @@ module.exports = (t, requireMySQL) => {
               client.query('SELECT 1 + 1 AS solution', (err) => {
                 var seg = helper.agent.tracer.getSegment().parent
 
+                const attributes = seg.getAttributes()
+
                 t.error(err)
                 t.ok(seg, 'there is a segment')
                 t.equal(
-                  seg.parameters.host,
+                  attributes.host,
                   utils.getDelocalizedHostname(params.host),
                   'set host'
                 )
                 t.equal(
-                  seg.parameters.database_name,
+                  attributes.database_name,
                   'test_db',
                   'set database name'
                 )
                 t.equal(
-                  seg.parameters.port_path_or_id,
+                  attributes.port_path_or_id,
                   '3306',
                   'set port'
                 )
                 withRetry.release(client)
-                txn.end(() => {
-                  checkQueries(t, helper)
-                  t.end()
-                })
+                txn.end()
+                checkQueries(t, helper)
+                t.end()
               })
             })
           })
@@ -228,22 +226,22 @@ module.exports = (t, requireMySQL) => {
           })
 
           setTimeout(function actualEnd() {
-            txn.end((transaction) => {
-              withRetry.release(client)
-              t.ok(results && ended, 'result and end events should occur')
-              var traceRoot = transaction.trace.root
-              var traceRootDuration = traceRoot.timer.getDurationInMillis()
-              var segment = findSegment(
-                traceRoot,
-                'Datastore/statement/MySQL/unknown/select'
-              )
-              var queryNodeDuration = segment.timer.getDurationInMillis()
-              t.ok(Math.abs(duration - queryNodeDuration) < 50,
-                  'query duration should be roughly be the time between query and end')
-              t.ok(traceRootDuration - queryNodeDuration > 900,
-                  'query duration should be small compared to transaction duration')
-              t.end()
-            })
+            txn.end()
+
+            withRetry.release(client)
+            t.ok(results && ended, 'result and end events should occur')
+            var traceRoot = txn.trace.root
+            var traceRootDuration = traceRoot.timer.getDurationInMillis()
+            var segment = findSegment(
+              traceRoot,
+              'Datastore/statement/MySQL/unknown/select'
+            )
+            var queryNodeDuration = segment.timer.getDurationInMillis()
+            t.ok(Math.abs(duration - queryNodeDuration) < 50,
+                'query duration should be roughly be the time between query and end')
+            t.ok(traceRootDuration - queryNodeDuration > 900,
+                'query duration should be small compared to transaction duration')
+            t.end()
           }, 2000)
         })
       })
@@ -269,27 +267,26 @@ module.exports = (t, requireMySQL) => {
 
           query.on('end', function endCallback() {
             setTimeout(() => {
-              txn.end((transaction) => {
-                withRetry.release(client)
-                var traceRoot = transaction.trace.root
-                var querySegment = traceRoot.children[0]
-                t.equal(
-                  querySegment.children.length, 2,
-                  'the query segment should have two children'
-                )
+              txn.end()
+              withRetry.release(client)
+              var traceRoot = txn.trace.root
+              var querySegment = traceRoot.children[0]
+              t.equal(
+                querySegment.children.length, 2,
+                'the query segment should have two children'
+              )
 
-                var childSegment = querySegment.children[1]
-                t.equal(
-                  childSegment.name, 'Callback: endCallback',
-                  'children should be callbacks'
-                )
-                var grandChildSegment = childSegment.children[0]
-                t.equal(
-                  grandChildSegment.name, 'timers.setTimeout',
-                  'grand children should be timers'
-                )
-                t.end()
-              })
+              var childSegment = querySegment.children[1]
+              t.equal(
+                childSegment.name, 'Callback: endCallback',
+                'children should be callbacks'
+              )
+              var grandChildSegment = childSegment.children[0]
+              t.equal(
+                grandChildSegment.name, 'timers.setTimeout',
+                'grand children should be timers'
+              )
+              t.end()
             }, 100)
           })
         })
@@ -313,10 +310,9 @@ module.exports = (t, requireMySQL) => {
 
             t.transaction(txn)
             withRetry.release(client)
-            txn.end(() => {
-              checkQueries(t, helper)
-              t.end()
-            })
+            txn.end()
+            checkQueries(t, helper)
+            t.end()
           })
         })
       })
@@ -339,10 +335,9 @@ module.exports = (t, requireMySQL) => {
 
             t.transaction(txn)
             withRetry.release(client)
-            txn.end(() => {
-              checkQueries(t, helper)
-              t.end()
-            })
+            txn.end()
+            checkQueries(t, helper)
+            t.end()
           })
         })
       })


### PR DESCRIPTION
* Updates tests to make agent v5 compatible.
* Bumps newrelic dependency minimum to `5.9.1` which includes critical fix for this module to load for `mysql2/promise`.
* Reorganizes promises test to expose bug that is fixed in agent version `5.9.1`.
* Enforces supported Node versions (aligns with agent).
* Fixes bug with `mysql2/promise` where underlying callback instrumentation would look at the wrong query arg for the callback.