### PR TITLE
NODE-2170 Add Node 12 support. Drop Node 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ node_js:
   - "12"
 env:
   - SUITE=lint
-  - SUITE=unit
   - SUITE=versioned
 matrix:
   exclude:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,18 @@
 language: node_js
 node_js:
-  - "6"
-  - "7"
   - "8"
-  - "9"
   - "10"
+  - "12"
 env:
   - SUITE=lint
   - SUITE=unit
   - SUITE=versioned
 matrix:
   exclude:
-    - node_js: "6"
-      env: SUITE=lint
-    - node_js: "7"
       env: SUITE=lint
     - node_js: "8"
       env: SUITE=lint
-    - node_js: "9"
+    - node_js: "10"
       env: SUITE=lint
 services:
   - mysql

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ env:
   - SUITE=versioned
 matrix:
   exclude:
-      env: SUITE=lint
     - node_js: "8"
       env: SUITE=lint
     - node_js: "10"

--- a/package.json
+++ b/package.json
@@ -36,10 +36,10 @@
     "generic-pool": "^2.5.4",
     "mysql": "^2.17.1",
     "mysql2": "^1.7.0",
-    "newrelic": "^5.13",
+    "newrelic": "^6.0.0",
     "tap": "^14.7.1"
   },
   "peerDependencies": {
-    "newrelic": ">=5.13"
+    "newrelic": ">=6.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/newrelic/node-newrelic-mysql#readme",
   "engines": {
-    "node": ">=6.0.0 <11.0.0"
+    "node": ">=8.0.0"
   },
   "devDependencies": {
     "@newrelic/test-utilities": "^3.0.0",
@@ -34,12 +34,12 @@
     "coveralls": "^3.0.2",
     "eslint": "^5.7.0",
     "generic-pool": "^2.5.4",
-    "mysql": "^2.16.0",
-    "mysql2": "^1.6.1",
-    "newrelic": "^5.9.1",
-    "tap": "^11.1.5"
+    "mysql": "^2.17.1",
+    "mysql2": "^1.7.0",
+    "newrelic": "^5.13",
+    "tap": "^14.7.1"
   },
   "peerDependencies": {
-    "newrelic": ">=5.9.1"
+    "newrelic": ">=5.13"
   }
 }

--- a/tests/versioned/mysql/package.json
+++ b/tests/versioned/mysql/package.json
@@ -5,7 +5,7 @@
   "tests": [
     {
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=8 <= 10"
       },
       "dependencies": {
         "mysql": ">=2.2.0"

--- a/tests/versioned/mysql/package.json
+++ b/tests/versioned/mysql/package.json
@@ -5,7 +5,7 @@
   "tests": [
     {
       "engines": {
-        "node": ">=8 <= 10"
+        "node": ">=8"
       },
       "dependencies": {
         "mysql": ">=2.2.0"

--- a/tests/versioned/mysql2/package.json
+++ b/tests/versioned/mysql2/package.json
@@ -5,10 +5,10 @@
   "tests": [
     {
       "engines": {
-        "node": ">=0.10"
+        "node": ">=8.0 < 11.0"
       },
       "dependencies": {
-        "mysql2": ">=1 <1.3.1"
+        "mysql2": ">=1.3.1 <= 1.6.5"
       },
       "files": [
         "basic-pool.tap.js",
@@ -20,10 +20,10 @@
     },
     {
       "engines": {
-        "node": ">=4.0"
+        "node": ">=12.0"
       },
       "dependencies": {
-        "mysql2": ">=1.3.1"
+        "mysql2": ">=1.7.0"
       },
       "files": [
         "basic-pool.tap.js",


### PR DESCRIPTION
## CHANGELOG
* **BREAKING** Removed support for Node 6, 7, and 9.

  The minimum supported version is now Node v8. For further information on our support policy, see: https://docs.newrelic.com/docs/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.

* Added support for Node v12.

* Bumps `tap` to latest major version.

## INTERNAL LINKS

## NOTES

[Resolved] ~This currently has failing tests on `promises.tap.js` due to a test issue for the main agent where tests making multiple manual calls of `shimmer.patchModule` result in us unable to determine the "module root" since we've cleared our cache but node is still using its cache (Node 12).~
