### PR TITLE
update node-agent peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
     "tap": "^14.7.1"
   },
   "peerDependencies": {
-    "newrelic": ">=6.0.0"
+    "newrelic": ">=6.11.0"
   }
 }


### PR DESCRIPTION
## Proposed Release Notes
- Update New Relic Node Agent Peer dependency to 6.11.0

## Links

## Details
