### PR TITLE
Added support for client.execute

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -43,7 +43,7 @@ code, the source code can be found at [https://github.com/newrelic/node-newrelic
 
 ### @newrelic/eslint-config
 
-This product includes source derived from [@newrelic/eslint-config](https://github.com/newrelic/eslint-config-newrelic) ([v0.0.2](https://github.com/newrelic/eslint-config-newrelic/tree/v0.0.2)), distributed under the [Apache-2.0 License](https://github.com/newrelic/eslint-config-newrelic/blob/v0.0.2/LICENSE):
+This product includes source derived from [@newrelic/eslint-config](https://github.com/newrelic/eslint-config-newrelic) ([v0.0.4](https://github.com/newrelic/eslint-config-newrelic/tree/v0.0.4)), distributed under the [Apache-2.0 License](https://github.com/newrelic/eslint-config-newrelic/blob/v0.0.4/LICENSE):
 
 ```
                                  Apache License

--- a/index.js
+++ b/index.js
@@ -13,6 +13,9 @@
 const newrelic = require('newrelic')
 const instrumentation = require('./lib/instrumentation')
 
+/** We only need to register the instrumentation once for both mysql and mysql2
+ *  because there is some 🪄 in shimmer
+ * See: https://github.com/newrelic/node-newrelic/blob/main/lib/shimmer.js#L459
+ */
 newrelic.instrumentDatastore('mysql', instrumentation.callbackInitialize)
-newrelic.instrumentDatastore('mysql2', instrumentation.callbackInitialize)
 newrelic.instrumentDatastore('mysql2/promise', instrumentation.promiseInitialize)

--- a/lib/instrumentation.js
+++ b/lib/instrumentation.js
@@ -13,7 +13,7 @@ exports.callbackInitialize = function callbackInitialize(shim, mysql) {
   function wrapCreateConnection(shim, fn, fnName, connection) {
     shim.logger.debug('Wrapping Connection#query')
     if (wrapQueriable(shim, connection, false)) {
-      var connProto = Object.getPrototypeOf(connection)
+      const connProto = Object.getPrototypeOf(connection)
       shim.setInternalProperty(connProto, '__NR_storeDatabase', true)
       shim.unwrap(mysql, 'createConnection')
     }
@@ -30,7 +30,7 @@ exports.callbackInitialize = function callbackInitialize(shim, mysql) {
   shim.wrapReturn(mysql, 'createPoolCluster', wrapCreatePoolCluster)
   function wrapCreatePoolCluster(shim, fn, fnName, poolCluster) {
     shim.logger.debug('Wrapping PoolCluster#of')
-    var proto = Object.getPrototypeOf(poolCluster)
+    const proto = Object.getPrototypeOf(poolCluster)
     shim.wrapReturn(proto, 'of', wrapPoolClusterOf)
     function wrapPoolClusterOf(shim, of, _n, poolNamespace) {
       if (wrapGetConnection(shim, poolNamespace)) {
@@ -66,11 +66,11 @@ function wrapGetConnection(shim, connectable) {
     return false
   }
 
-  var proto = Object.getPrototypeOf(connectable)
+  const proto = Object.getPrototypeOf(connectable)
   shim.wrap(proto, 'getConnection', function doWrapGetConnection(shim, fn) {
     return function wrappedGetConnection() {
-      var args = shim.toArray(arguments)
-      var cbIdx = args.length - 1
+      const args = shim.toArray(arguments)
+      const cbIdx = args.length - 1
 
       if (shim.isFunction(args[cbIdx]) && !shim.isWrapped(args[cbIdx])) {
         shim.logger.trace(
@@ -79,7 +79,7 @@ function wrapGetConnection(shim, connectable) {
           },
           'Wrapping callback with segment'
         )
-        var cb = args[cbIdx]
+        let cb = args[cbIdx]
         if (!shim.__wrappedPoolConnection) {
           cb = shim.wrap(cb, wrapGetConnectionCallback)
         }
@@ -124,7 +124,7 @@ function wrapQueriable(shim, queriable, isPoolQuery) {
     return false
   }
 
-  var proto = Object.getPrototypeOf(queriable)
+  const proto = Object.getPrototypeOf(queriable)
   if (isPoolQuery) {
     shim.recordQuery(proto, 'query', describePoolQuery)
   } else {
@@ -136,8 +136,8 @@ function wrapQueriable(shim, queriable, isPoolQuery) {
 }
 
 function extractQueryArgs(shim, args) {
-  var query = ''
-  var callback = null
+  let query = ''
+  let callback = null
 
   // Figure out the query parameter.
   if (shim.isString(args[0])) {
@@ -165,10 +165,10 @@ function extractQueryArgs(shim, args) {
 
 function describeQuery(shim, queryFn, fnName, args) {
   shim.logger.trace('Recording query')
-  var extractedArgs = extractQueryArgs(shim, args)
+  const extractedArgs = extractQueryArgs(shim, args)
 
   // Pull out instance attributes.
-  var parameters = getInstanceParameters(shim, this, extractedArgs.query)
+  const parameters = getInstanceParameters(shim, this, extractedArgs.query)
 
   shim.logger.trace(
     {
@@ -190,7 +190,7 @@ function describeQuery(shim, queryFn, fnName, args) {
 
 function describePoolQuery(shim, queryFn, fnName, args) {
   shim.logger.trace('Recording pool query')
-  var extractedArgs = extractQueryArgs(shim, args)
+  const extractedArgs = extractQueryArgs(shim, args)
   return {
     stream: true,
     query: null,
@@ -201,10 +201,10 @@ function describePoolQuery(shim, queryFn, fnName, args) {
 }
 
 function getInstanceParameters(shim, queryable, query) {
-  var parameters = { host: null, port_path_or_id: null, database_name: null }
-  var conf = queryable.config
+  const parameters = { host: null, port_path_or_id: null, database_name: null }
+  let conf = queryable.config
   conf = (conf && conf.connectionConfig) || conf
-  var databaseName = queryable.__NR_databaseName || null
+  let databaseName = queryable.__NR_databaseName || null
   if (conf) {
     parameters.database_name = databaseName = databaseName || conf.database
 
@@ -226,7 +226,7 @@ function getInstanceParameters(shim, queryable, query) {
 
 function storeDatabaseName(shim, queryable, query) {
   if (queryable.__NR_storeDatabase) {
-    var databaseName = shim.getDatabaseNameFromUseQuery(query)
+    const databaseName = shim.getDatabaseNameFromUseQuery(query)
     if (databaseName) {
       shim.setInternalProperty(queryable, '__NR_databaseName', databaseName)
     }

--- a/lib/instrumentation.js
+++ b/lib/instrumentation.js
@@ -12,7 +12,7 @@ exports.callbackInitialize = function callbackInitialize(shim, mysql) {
   shim.wrapReturn(mysql, 'createConnection', wrapCreateConnection)
   function wrapCreateConnection(shim, fn, fnName, connection) {
     shim.logger.debug('Wrapping Connection#query')
-    if (wrapQueriable(shim, connection, false)) {
+    if (wrapQueryable(shim, connection, false)) {
       const connProto = Object.getPrototypeOf(connection)
       shim.setInternalProperty(connProto, '__NR_storeDatabase', true)
       shim.unwrap(mysql, 'createConnection')
@@ -22,7 +22,7 @@ exports.callbackInitialize = function callbackInitialize(shim, mysql) {
   shim.wrapReturn(mysql, 'createPool', wrapCreatePool)
   function wrapCreatePool(shim, fn, fnName, pool) {
     shim.logger.debug('Wrapping Pool#query and Pool#getConnection')
-    if (wrapQueriable(shim, pool, true) && wrapGetConnection(shim, pool)) {
+    if (wrapQueryable(shim, pool, true) && wrapGetConnection(shim, pool)) {
       shim.unwrap(mysql, 'createPool')
     }
   }
@@ -96,7 +96,7 @@ function wrapGetConnectionCallback(shim, cb) {
   return function wrappedGetConnectionCallback(err, conn) {
     try {
       shim.logger.debug('Wrapping PoolConnection#query')
-      if (!err && wrapQueriable(shim, conn, false)) {
+      if (!err && wrapQueryable(shim, conn, false)) {
         // Leave getConnection wrapped in order to maintain TX state, but we can
         // simplify the wrapping of its callback in future calls.
         shim.__wrappedPoolConnection = true
@@ -111,20 +111,20 @@ function wrapGetConnectionCallback(shim, cb) {
   }
 }
 
-function wrapQueriable(shim, queriable, isPoolQuery) {
-  if (!queriable || !queriable.query || shim.isWrapped(queriable.query)) {
+function wrapQueryable(shim, queryable, isPoolQuery) {
+  if (!queryable || !queryable.query || shim.isWrapped(queryable.query)) {
     shim.logger.debug(
       {
-        queriable: !!queriable,
-        query: !!(queriable && queriable.query),
-        isWrapped: !!(queriable && shim.isWrapped(queriable.query))
+        queryable: !!queryable,
+        query: !!(queryable && queryable.query),
+        isWrapped: !!(queryable && shim.isWrapped(queryable.query))
       },
-      'Not wrappying queriable'
+      'Not wrapping queryable'
     )
     return false
   }
 
-  const proto = Object.getPrototypeOf(queriable)
+  const proto = Object.getPrototypeOf(queryable)
 
   let describe
   if (isPoolQuery) {
@@ -136,7 +136,7 @@ function wrapQueriable(shim, queriable, isPoolQuery) {
 
   shim.recordQuery(proto, 'query', describe)
 
-  if (queriable.execute) {
+  if (queryable.execute) {
     shim.recordQuery(proto, 'execute', describe)
   }
 

--- a/lib/instrumentation.js
+++ b/lib/instrumentation.js
@@ -125,11 +125,19 @@ function wrapQueriable(shim, queriable, isPoolQuery) {
   }
 
   const proto = Object.getPrototypeOf(queriable)
+
+  let describe
   if (isPoolQuery) {
-    shim.recordQuery(proto, 'query', describePoolQuery)
+    describe = describePoolQuery
   } else {
-    shim.recordQuery(proto, 'query', describeQuery)
+    describe = describeQuery
     shim.setInternalProperty(proto, '__NR_databaseName', null)
+  }
+
+  shim.recordQuery(proto, 'query', describe)
+
+  if (queriable.execute) {
+    shim.recordQuery(proto, 'execute', describe)
   }
 
   return true

--- a/nr-hooks.js
+++ b/nr-hooks.js
@@ -7,15 +7,14 @@
 
 const instrumentation = require('./lib/instrumentation')
 
+/** We only need to register the instrumentation once for both mysql and mysql2
+ *  because there is some 🪄 in shimmer
+ * See: https://github.com/newrelic/node-newrelic/blob/main/lib/shimmer.js#L459
+ */
 module.exports = [
   {
     type: 'datastore',
     moduleName: 'mysql',
-    onRequire: instrumentation.callbackInitialize
-  },
-  {
-    type: 'datastore',
-    moduleName: 'mysql2',
     onRequire: instrumentation.callbackInitialize
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.1.1",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@newrelic/eslint-config": "^0.0.2",
+        "@newrelic/eslint-config": "^0.0.4",
         "@newrelic/newrelic-oss-cli": "^0.1.2",
         "@newrelic/test-utilities": "^6.3.0",
         "async": "^3.2.0",
@@ -511,9 +511,9 @@
       }
     },
     "node_modules/@newrelic/eslint-config": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@newrelic/eslint-config/-/eslint-config-0.0.2.tgz",
-      "integrity": "sha512-fMn9e4hShInAuZxYg5dV/qmJ48Qj6JE8eQqE6XyPiDsTriEt6A5H88PFQ50V/xmWGrSxnvmmCnXzdWgxUDaqbg==",
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@newrelic/eslint-config/-/eslint-config-0.0.4.tgz",
+      "integrity": "sha512-ER8LjoFbbIciPiVfHJB36nhWbo/MbKfNe8IiG+p3AHIUmm/pGqz+wF38kqsuhKA1gsr6wUNIHFQiS/4FMWF3Kg==",
       "dev": true,
       "engines": {
         "node": ">=12"
@@ -11366,9 +11366,9 @@
       "requires": {}
     },
     "@newrelic/eslint-config": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@newrelic/eslint-config/-/eslint-config-0.0.2.tgz",
-      "integrity": "sha512-fMn9e4hShInAuZxYg5dV/qmJ48Qj6JE8eQqE6XyPiDsTriEt6A5H88PFQ50V/xmWGrSxnvmmCnXzdWgxUDaqbg==",
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@newrelic/eslint-config/-/eslint-config-0.0.4.tgz",
+      "integrity": "sha512-ER8LjoFbbIciPiVfHJB36nhWbo/MbKfNe8IiG+p3AHIUmm/pGqz+wF38kqsuhKA1gsr6wUNIHFQiS/4FMWF3Kg==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "node": ">=12.0.0"
   },
   "devDependencies": {
-    "@newrelic/eslint-config": "^0.0.2",
+    "@newrelic/eslint-config": "^0.0.4",
     "@newrelic/newrelic-oss-cli": "^0.1.2",
     "@newrelic/test-utilities": "^6.3.0",
     "async": "^3.2.0",

--- a/tests/versioned/common/transactions.js
+++ b/tests/versioned/common/transactions.js
@@ -19,7 +19,12 @@ module.exports = (t, requireMySQL) => {
     t.beforeEach(async function () {
       // set up the instrumentation before loading MySQL
       helper = utils.TestAgent.makeInstrumented()
-      mysql = requireMySQL(helper)
+      helper.registerInstrumentation({
+        moduleName: 'mysql',
+        type: 'datastore',
+        onRequire: require('../../../lib/instrumentation').callbackInitialize
+      })
+      mysql = requireMySQL()
       await setup(mysql)
     })
 

--- a/tests/versioned/mysql/basic-pool.tap.js
+++ b/tests/versioned/mysql/basic-pool.tap.js
@@ -12,15 +12,5 @@ utils(tap)
 
 tap.test('mysql basic pool', (t) => {
   t.autoend()
-  require('../common/basic-pool')(t, (helper) => {
-    if (helper) {
-      helper.registerInstrumentation({
-        moduleName: 'mysql',
-        type: 'datastore',
-        onRequire: require('../../../lib/instrumentation').callbackInitialize
-      })
-    }
-
-    return require('mysql')
-  })
+  require('../common/basic-pool')(t, () => require('mysql'))
 })

--- a/tests/versioned/mysql/basic.tap.js
+++ b/tests/versioned/mysql/basic.tap.js
@@ -14,14 +14,5 @@ utils(tap)
 
 tap.test('mysql basic', (t) => {
   t.autoend()
-  require('../common/basic')(t, (helper) => {
-    if (helper) {
-      helper.registerInstrumentation({
-        moduleName: 'mysql',
-        type: 'datastore',
-        onRequire: require('../../../lib/instrumentation').callbackInitialize
-      })
-    }
-    return require('mysql')
-  })
+  require('../common/basic')(t, 'mysql', () => require('mysql'))
 })

--- a/tests/versioned/mysql/pooling.tap.js
+++ b/tests/versioned/mysql/pooling.tap.js
@@ -12,15 +12,5 @@ utils(tap)
 
 tap.test('mysql pooling', (t) => {
   t.autoend()
-  require('../common/pooling')(t, (helper) => {
-    if (helper) {
-      helper.registerInstrumentation({
-        moduleName: 'mysql',
-        type: 'datastore',
-        onRequire: require('../../../lib/instrumentation').callbackInitialize
-      })
-    }
-
-    return require('mysql')
-  })
+  require('../common/pooling')(t, () => require('mysql'))
 })

--- a/tests/versioned/mysql/transactions.tap.js
+++ b/tests/versioned/mysql/transactions.tap.js
@@ -12,15 +12,5 @@ utils(tap)
 
 tap.test('mysql transactions', (t) => {
   t.autoend()
-  require('../common/transactions')(t, (helper) => {
-    if (helper) {
-      helper.registerInstrumentation({
-        moduleName: 'mysql',
-        type: 'datastore',
-        onRequire: require('../../../lib/instrumentation').callbackInitialize
-      })
-    }
-
-    return require('mysql')
-  })
+  require('../common/transactions')(t, () => require('mysql'))
 })

--- a/tests/versioned/mysql2/basic-pool.tap.js
+++ b/tests/versioned/mysql2/basic-pool.tap.js
@@ -10,17 +10,7 @@ const utils = require('@newrelic/test-utilities')
 
 utils(tap)
 
-tap.test('mysql basic pool', (t) => {
+tap.test('mysql2 basic pool', (t) => {
   t.autoend()
-  require('../common/basic-pool')(t, (helper) => {
-    if (helper) {
-      helper.registerInstrumentation({
-        moduleName: 'mysql2',
-        type: 'datastore',
-        onRequire: require('../../../lib/instrumentation').callbackInitialize
-      })
-    }
-
-    return require('mysql2')
-  })
+  require('../common/basic-pool')(t, () => require('mysql2'))
 })

--- a/tests/versioned/mysql2/basic.tap.js
+++ b/tests/versioned/mysql2/basic.tap.js
@@ -12,16 +12,7 @@ const utils = require('@newrelic/test-utilities')
 
 utils(tap)
 
-tap.test('mysql basic', (t) => {
+tap.test('mysql2 basic', (t) => {
   t.autoend()
-  require('../common/basic')(t, (helper) => {
-    if (helper) {
-      helper.registerInstrumentation({
-        moduleName: 'mysql2',
-        type: 'datastore',
-        onRequire: require('../../../lib/instrumentation').callbackInitialize
-      })
-    }
-    return require('mysql2')
-  })
+  require('../common/basic')(t, 'mysql2', () => require('mysql2'))
 })

--- a/tests/versioned/mysql2/pooling.tap.js
+++ b/tests/versioned/mysql2/pooling.tap.js
@@ -10,17 +10,7 @@ const utils = require('@newrelic/test-utilities')
 
 utils(tap)
 
-tap.test('mysql pooling', (t) => {
+tap.test('mysql2 pooling', (t) => {
   t.autoend()
-  require('../common/pooling')(t, (helper) => {
-    if (helper) {
-      helper.registerInstrumentation({
-        moduleName: 'mysql2',
-        type: 'datastore',
-        onRequire: require('../../../lib/instrumentation').callbackInitialize
-      })
-    }
-
-    return require('mysql2')
-  })
+  require('../common/pooling')(t, () => require('mysql2'))
 })

--- a/tests/versioned/mysql2/promises.tap.js
+++ b/tests/versioned/mysql2/promises.tap.js
@@ -31,7 +31,7 @@ tap.test('mysql2 promises', { timeout: 30000 }, (t) => {
     // Stub the normal mysql2 instrumentation to avoid it hiding issues with the
     // promise instrumentation.
     helper.registerInstrumentation({
-      moduleName: 'mysql2',
+      moduleName: 'mysql',
       type: 'datastore',
       onRequire: () => {}
     })
@@ -129,7 +129,7 @@ tap.test('mysql2 promises', { timeout: 30000 }, (t) => {
 function checkQueries(t, helper) {
   const querySamples = helper.agent.queries.samples
   t.ok(querySamples.size > 0, 'there should be a query sample')
-  for (let sample of querySamples.values()) {
+  for (const sample of querySamples.values()) {
     t.ok(sample.total > 0, 'the samples should have positive duration')
   }
 }

--- a/tests/versioned/mysql2/transactions.tap.js
+++ b/tests/versioned/mysql2/transactions.tap.js
@@ -10,17 +10,7 @@ const utils = require('@newrelic/test-utilities')
 
 utils(tap)
 
-tap.test('mysql transactions', (t) => {
+tap.test('mysql2 transactions', (t) => {
   t.autoend()
-  require('../common/transactions')(t, (helper) => {
-    if (helper) {
-      helper.registerInstrumentation({
-        moduleName: 'mysql2',
-        type: 'datastore',
-        onRequire: require('../../../lib/instrumentation').callbackInitialize
-      })
-    }
-
-    return require('mysql2')
-  })
+  require('../common/transactions')(t, () => require('mysql2'))
 })

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,20 +1,20 @@
 {
-  "lastUpdated": "Fri Feb 11 2022 15:38:24 GMT-0800 (Pacific Standard Time)",
+  "lastUpdated": "Tue Mar 29 2022 13:18:46 GMT-0400 (Eastern Daylight Time)",
   "projectName": "New Relic MySql Instrumentation",
   "projectUrl": "https://github.com/newrelic/node-newrelic-mysql",
   "includeOptDeps": false,
   "includeDev": true,
   "dependencies": {},
   "devDependencies": {
-    "@newrelic/eslint-config@0.0.2": {
+    "@newrelic/eslint-config@0.0.4": {
       "name": "@newrelic/eslint-config",
-      "version": "0.0.2",
-      "range": "^0.0.2",
+      "version": "0.0.4",
+      "range": "^0.0.4",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/newrelic/eslint-config-newrelic",
-      "versionedRepoUrl": "https://github.com/newrelic/eslint-config-newrelic/tree/v0.0.2",
+      "versionedRepoUrl": "https://github.com/newrelic/eslint-config-newrelic/tree/v0.0.4",
       "licenseFile": "node_modules/@newrelic/eslint-config/LICENSE",
-      "licenseUrl": "https://github.com/newrelic/eslint-config-newrelic/blob/v0.0.2/LICENSE",
+      "licenseUrl": "https://github.com/newrelic/eslint-config-newrelic/blob/v0.0.4/LICENSE",
       "licenseTextSource": "file",
       "publisher": "New Relic Node.js agent team",
       "email": "nodejs@newrelic.com"


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Added support for `mysql2` `client.execute`.
 * Fixed `mysql2` versioned tests to use local instrumentation vs agent instrumentation.

## Links
Closes #59

## Details
I put a comment in the code but the versioned tests were never running against the local instrumentation.  This is because of the shimmer magic where when it sees `mysql2` being required load registered instrumentation for `mysql`.  The only registered instrumentation for `mysql` was in agent, thus never testing the instrumentation locally for `mysql2`.  We still have not decided if we're going to keep this module or bring it all back into the agent but this along with a pending PR for #47 will give feature parity.
